### PR TITLE
숫자게임 [STEP 2] Lingo, RED

### DIFF
--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -6,8 +6,53 @@
 
 import Foundation
 
-var targetStrikeCount: Int = 3
-var targetRange: ClosedRange<Int> = 1...9
+let targetStrikeCount: Int = 3
+let targetRange: ClosedRange<Int> = 1...9
+let totalMatchCount: Int = 9
+
+func main() {
+    print("""
+    1. 게임시작
+    2. 게임종료
+    원하는 기능을 선택해주세요 :
+    """, terminator: " ")
+    
+    guard let menuSelection = readLine() else {
+        return
+    }
+    
+    switch menuSelection {
+    case "1":
+        playNumberBaseBallGame()
+        main()
+    case "2":
+        break
+    default:
+        print("입력이 잘못되었습니다")
+        main()
+    }
+}
+
+func playNumberBaseBallGame() {
+    var gameStatus: Bool = true
+    var matchCount: Int = totalMatchCount
+    var strikeCount: Int = Int.zero
+    var ballCount: Int = Int.zero
+    
+    var playerNumbers: [Int] = []
+    let computerNumbers: [Int] = generateRandomNumbers()
+    
+    while matchCount > Int.zero && gameStatus {
+        playerNumbers = []
+        allocatePlayerNumbers(&playerNumbers)
+        (strikeCount, ballCount) = checkGameScore(playerNumbers, computerNumbers)
+        gameStatus = checkGameStatus(strikeCount)
+
+        matchCount -= 1
+        displayScore(strikeCount, ballCount)
+        displayScoreBoard(&matchCount, gameStatus)
+    }
+}
 
 func generateRandomNumbers(range: ClosedRange<Int> = targetRange, quantity: Int = targetStrikeCount) -> [Int] {
     guard range.count >= quantity else {
@@ -19,6 +64,53 @@ func generateRandomNumbers(range: ClosedRange<Int> = targetRange, quantity: Int 
         numbers.insert(Int.random(in: range))
     }
     return Array(numbers)
+}
+
+func allocatePlayerNumbers(_ playerNumbers: inout [Int]) {
+   while playerNumbers == [] {
+        playerNumbers = generatePlayerNumbers()
+    }
+}
+
+func generatePlayerNumbers() -> [Int] {
+    print("""
+    숫자 3개를 띄어쓰기로 구분하여 입력해주세요.
+    중복 숫자는 허용하지 않습니다.
+    입력 :
+    """, terminator: " ")
+    
+    guard let inputString = readLine() else { return [] }
+    
+    if validatePlayerNumbers(inputString) {
+        return convertInputToIntArray(inputString)
+    } else {
+        print("입력이 잘못되었습니다")
+        return []
+    }
+}
+
+func validatePlayerNumbers(_ inputString: String) -> Bool {
+    let inputNumber = convertInputToIntArray(inputString)
+    return checkDuplicated(inputNumber) && checkRanged(inputNumber)
+}
+
+func convertInputToIntArray(_ inputString: String) -> [Int] {
+    return inputString
+        .components(separatedBy: " ")
+        .compactMap { (number: String) -> Int? in
+            return Int(number)
+        }
+}
+
+func checkDuplicated(_ inputNumber: [Int]) -> Bool {
+    return inputNumber.count == Set(inputNumber).count
+}
+
+func checkRanged(_ inputNumber: [Int]) -> Bool {
+    return inputNumber
+        .filter { (number: Int) -> Bool in
+            return targetRange.contains(number)
+        }.count == targetStrikeCount
 }
 
 func checkGameScore(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> (Int, Int) {
@@ -45,87 +137,20 @@ func increaseGameScore(_ playerNumber: Int, _ computerNumber: Int, _ computerNum
     return (strikeCount, ballCount)
 }
 
-func convertArrayToString(of values: [Int]) -> String {
-    return values.map { (value: Int) -> String in
-        return String(value)
-    }.joined(separator: " ")
-}
 
-func checkDuplicated(_ inputNumber: [Int]) -> Bool {
-    return inputNumber.count == Set(inputNumber).count
-}
-
-func checkRanged(_ inputNumber: [Int]) -> Bool {
-    var isRanged: [Bool] = []
-    for number in inputNumber {
-        isRanged.append(targetRange.contains(number))
-    }
-
-    return isRanged.allSatisfy { (value: Bool) -> Bool in
-        return value == true
-    }
-}
-
-func validatePlayerNumbers(_ inputString: String) -> Bool {
-    let inputNumber = convertInputToIntArray(inputString)
-    return checkDuplicated(inputNumber) && checkRanged(inputNumber)
-}
-
-func convertInputToIntArray(_ inputString: String) -> [Int] {
-    let playerNumbers = inputString.components(separatedBy: " ")
-    return playerNumbers.compactMap { (number: String) -> Int? in
-        return Int(number)
-    }
-}
-
-func generatePlayerNumbers() -> [Int] {
-    print("숫자 3개를 띄어쓰기로 구분하여 입력해주세요.")
-    print("중복 숫자는 허용하지 않습니다.")
-    print("입력 : ", terminator: "")
-    guard let inputString = readLine() else { return [] }
-    
-    if validatePlayerNumbers(inputString) {
-        return convertInputToIntArray(inputString)
-    } else {
-        print("입력이 잘못되었습니다")
-        return []
-    }
-}
-
-func allocatePlayerNumbers(_ playerNumbers: inout [Int]) {
-   while playerNumbers == [] {
-        playerNumbers = generatePlayerNumbers()
-    }
-}
-
-func playNumberBaseBallGame() {
-    var playerNumbers: [Int] = []
-    var computerNumbers: [Int] = []
-    var matchCount: Int = 9
-    var strikeCount: Int = Int.zero
-    var ballCount: Int = Int.zero
-    
-    computerNumbers = generateRandomNumbers()
-    
-    while matchCount > Int.zero {
-        
-        playerNumbers = []
-        
-        allocatePlayerNumbers(&playerNumbers)
-        
-        (strikeCount, ballCount) = checkGameScore(playerNumbers, computerNumbers)
-        
-        matchCount -= 1
-        
-        displayScoreBoard(&matchCount, strikeCount, ballCount)
-    }
-}
-
-func displayScoreBoard(_ matchCount: inout Int, _ strikeCount: Int, _ ballCount: Int) {
-    print("\(strikeCount) 스트라이크, \(ballCount) 볼")
-    
+func checkGameStatus(_ strikeCount: Int) -> Bool {
     if strikeCount == targetStrikeCount {
-        matchCount = Int.zero
+        return false
+    }
+    return true
+}
+
+func displayScore(_ strikeCount: Int, _ ballCount: Int) {
+    print("\(strikeCount) 스트라이크, \(ballCount) 볼")
+}
+
+func displayScoreBoard(_ matchCount: inout Int, _ gameStatus: Bool) {
+    if gameStatus == false {
         print("사용자 승리!")
     } else if matchCount == Int.zero {
         print("남은 기회 : \(matchCount)")
@@ -135,30 +160,4 @@ func displayScoreBoard(_ matchCount: inout Int, _ strikeCount: Int, _ ballCount:
     }
 }
 
-func main() {
-    var gameStatus: Bool = true
-    
-    while gameStatus {
-        print("1. 게임시작")
-        print("2. 게임종료")
-        print("원하는 기능을 선택해주세요 : ", terminator: "")
-        
-        takePlayerIntention(&gameStatus)
-    }
-}
-
-func takePlayerIntention(_ gameStatus: inout Bool) {
-    guard let choice = readLine() else { return }
-    
-    switch choice {
-    case "1":
-        playNumberBaseBallGame()
-    case "2":
-        gameStatus = false
-    default:
-        print("입력이 잘못되었습니다")
-    }
-}
-
 main()
-

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -19,29 +19,31 @@ func generateRandomNumbers(range: ClosedRange<Int> = targetRange, quantity: Int 
 }
 
 func checkStrikeCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
-    var strikeCount: Int = 0
+    var strikeCount: Int = Int.zero
     
     for (playerNumber, computerNumber) in zip(playerNumbers, computerNumbers) {
-        increase(in: &strikeCount) { () -> Bool in
-            return playerNumber == computerNumber
-        }
+        increaseStrikeCount(in: &strikeCount, playerNumber, computerNumber)
     }
     return strikeCount
 }
 
 func checkBallCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
-    var ballCount: Int = 0
+    var ballCount: Int = Int.zero
     
     for (index, number) in playerNumbers.enumerated() {
-        increase(in: &ballCount) { () -> Bool in
-            return number != computerNumbers[index] && computerNumbers.contains(number)
-        }
+        increaseBallCount(in: &ballCount, computerNumbers, index, number)
     }
     return ballCount
 }
 
-func increase(in count: inout Int, condition: () -> Bool) {
-    if condition() {
+func increaseStrikeCount(in count: inout Int, _ playerNumber: Int, _ computerNumber: Int) {
+    if playerNumber == computerNumber {
+        count += 1
+    }
+}
+
+func increaseBallCount(in count: inout Int, _ computerNumbers: [Int], _ index: Int, _ number: Int) {
+    if number != computerNumbers[index] && computerNumbers.contains(number) {
         count += 1
     }
 }
@@ -76,24 +78,30 @@ func validatePlayerNumbers(_ inputString: String) -> Bool {
     return checkDuplicated(inputNumber) && checkEqualTargetStrikeCount(inputNumber) && checkRanged(inputNumber)
 }
 
-func convertInputToIntArray(_ inputNumber: String) -> [Int] {
-    let playerNumbers = inputNumber.components(separatedBy: " ")
-    return playerNumbers.compactMap { (stringNumber: String) -> Int? in
-        return Int(stringNumber)
+func convertInputToIntArray(_ inputString: String) -> [Int] {
+    let playerNumbers = inputString.components(separatedBy: " ")
+    return playerNumbers.compactMap { (number: String) -> Int? in
+        return Int(number)
     }
 }
 
-func createPlayerInput() -> [Int] {
+func generatePlayerNumbers() -> [Int] {
     print("숫자 3개를 띄어쓰기로 구분하여 입력해주세요.")
     print("중복 숫자는 허용하지 않습니다.")
     print("입력 : ", terminator: "")
-    guard let inputNumber = readLine() else { return [] }
+    guard let inputString = readLine() else { return [] }
     
-    if validatePlayerNumbers(inputNumber) {
-        return convertInputToIntArray(inputNumber)
+    if validatePlayerNumbers(inputString) {
+        return convertInputToIntArray(inputString)
     } else {
         print("입력이 잘못되었습니다")
         return []
+    }
+}
+
+func allocatePlayerNumbers(_ playerNumbers: inout [Int]) {
+   while playerNumbers == [] {
+        playerNumbers = generatePlayerNumbers()
     }
 }
 
@@ -101,17 +109,16 @@ func playNumberBaseBallGame() {
     var playerNumbers: [Int] = []
     var computerNumbers: [Int] = []
     var matchCount: Int = 9
-    var strikeCount: Int = 0
-    var ballCount: Int = 0
+    var strikeCount: Int = Int.zero
+    var ballCount: Int = Int.zero
     
     computerNumbers = generateRandomNumbers()
     
-    while matchCount > 0 {
+    while matchCount > Int.zero {
         
         playerNumbers = []
-        while playerNumbers == [] {
-            playerNumbers = createPlayerInput()
-        }
+        
+        allocatePlayerNumbers(&playerNumbers)
         
         strikeCount = checkStrikeCount(playerNumbers, computerNumbers)
         ballCount = checkBallCount(playerNumbers, computerNumbers)
@@ -126,9 +133,9 @@ func displayScoreBoard(_ matchCount: inout Int, _ strikeCount: Int, _ ballCount:
     print("\(strikeCount) 스트라이크, \(ballCount) 볼")
     
     if strikeCount == targetStrikeCount {
-        matchCount = 0
+        matchCount = Int.zero
         print("사용자 승리!")
-    } else if matchCount == 0 {
+    } else if matchCount == Int.zero {
         print("남은 기회 : \(matchCount)")
         print("컴퓨터 승리...!")
     } else {

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -52,39 +52,28 @@ func convertArrayToString(of values: [Int]) -> String {
     }.joined(separator: " ")
 }
 
-func validatePlayerNumbers(_ inputNumber: String) -> Bool {
-    var isNumber: Bool = false
-    var isEqualWithTargetStrikeCount: Bool = false
-    var isNotDuplicated: Bool = false
-    var isRanged: Bool = false
-    let playerNumbers = inputNumber.components(separatedBy: " ")
-    var setPlayerNumbers: Set<String> = []
-    setPlayerNumbers = Set(playerNumbers)
-    
-    if playerNumbers.count == targetStrikeCount {
-        isEqualWithTargetStrikeCount = true
+func checkEqualTargetStrikeCount(_ inputNumber: [Int]) -> Bool {
+    return inputNumber.count == targetStrikeCount
+}
+
+func checkDuplicated(_ inputNumber: [Int]) -> Bool {
+    return inputNumber.count == Set(inputNumber).count
+}
+
+func checkRanged(_ inputNumber: [Int]) -> Bool {
+    var isRanged: [Bool] = []
+    for number in inputNumber {
+        isRanged.append(targetRange.contains(number))
     }
-    
-    for numbers in playerNumbers {
-        isNumber = numbers.allSatisfy { value in
-            value.isNumber
-        }
+
+    return isRanged.allSatisfy { (value: Bool) -> Bool in
+        return value == true
     }
-    
-    if playerNumbers.count == setPlayerNumbers.count {
-        isNotDuplicated = true
-    }
-    
-    let intPlayerNumbers = setPlayerNumbers.compactMap { (number: String) -> Int? in
-        return Int(number)
-    }
-    
-    for number in intPlayerNumbers {
-        if targetRange.contains(number) {
-            isRanged = true
-        }
-    }
-    return isNumber && isEqualWithTargetStrikeCount && isNotDuplicated && isRanged
+}
+
+func validatePlayerNumbers(_ inputString: String) -> Bool {
+    let inputNumber = convertInputToIntArray(inputString)
+    return checkDuplicated(inputNumber) && checkEqualTargetStrikeCount(inputNumber) && checkRanged(inputNumber)
 }
 
 func convertInputToIntArray(_ inputNumber: String) -> [Int] {

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -10,6 +10,9 @@ var targetStrikeCount: Int = 3
 var targetRange: ClosedRange<Int> = 1...9
 
 func generateRandomNumbers(range: ClosedRange<Int> = targetRange, quantity: Int = targetStrikeCount) -> [Int] {
+    guard range.count >= quantity else {
+        return []
+    }
     var numbers: Set<Int> = []
 
     while numbers.count < quantity {
@@ -18,44 +21,34 @@ func generateRandomNumbers(range: ClosedRange<Int> = targetRange, quantity: Int 
     return Array(numbers)
 }
 
-func checkStrikeCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
+func checkGameScore(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> (Int, Int) {
     var strikeCount: Int = Int.zero
-    
+    var ballCount: Int = Int.zero
+
     for (playerNumber, computerNumber) in zip(playerNumbers, computerNumbers) {
-        increaseStrikeCount(in: &strikeCount, playerNumber, computerNumber)
+        let (strike, ball) = increaseGameScore(playerNumber, computerNumber, computerNumbers)
+        strikeCount += strike
+        ballCount += ball
     }
-    return strikeCount
+    return (strikeCount, ballCount)
 }
 
-func checkBallCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
+func increaseGameScore(_ playerNumber: Int, _ computerNumber: Int, _ computerNumbers: [Int]) -> (Int, Int) {
+    var strikeCount = Int.zero
     var ballCount: Int = Int.zero
     
-    for (index, number) in playerNumbers.enumerated() {
-        increaseBallCount(in: &ballCount, computerNumbers, index, number)
-    }
-    return ballCount
-}
-
-func increaseStrikeCount(in count: inout Int, _ playerNumber: Int, _ computerNumber: Int) {
     if playerNumber == computerNumber {
-        count += 1
+        strikeCount += 1
+    } else if computerNumbers.contains(playerNumber) {
+        ballCount += 1
     }
-}
-
-func increaseBallCount(in count: inout Int, _ computerNumbers: [Int], _ index: Int, _ number: Int) {
-    if number != computerNumbers[index] && computerNumbers.contains(number) {
-        count += 1
-    }
+    return (strikeCount, ballCount)
 }
 
 func convertArrayToString(of values: [Int]) -> String {
     return values.map { (value: Int) -> String in
         return String(value)
     }.joined(separator: " ")
-}
-
-func checkEqualTargetStrikeCount(_ inputNumber: [Int]) -> Bool {
-    return inputNumber.count == targetStrikeCount
 }
 
 func checkDuplicated(_ inputNumber: [Int]) -> Bool {
@@ -75,7 +68,7 @@ func checkRanged(_ inputNumber: [Int]) -> Bool {
 
 func validatePlayerNumbers(_ inputString: String) -> Bool {
     let inputNumber = convertInputToIntArray(inputString)
-    return checkDuplicated(inputNumber) && checkEqualTargetStrikeCount(inputNumber) && checkRanged(inputNumber)
+    return checkDuplicated(inputNumber) && checkRanged(inputNumber)
 }
 
 func convertInputToIntArray(_ inputString: String) -> [Int] {
@@ -120,8 +113,7 @@ func playNumberBaseBallGame() {
         
         allocatePlayerNumbers(&playerNumbers)
         
-        strikeCount = checkStrikeCount(playerNumbers, computerNumbers)
-        ballCount = checkBallCount(playerNumbers, computerNumbers)
+        (strikeCount, ballCount) = checkGameScore(playerNumbers, computerNumbers)
         
         matchCount -= 1
         
@@ -169,3 +161,4 @@ func takePlayerIntention(_ gameStatus: inout Bool) {
 }
 
 main()
+

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -1,6 +1,6 @@
 //
 //  NumberBaseball - main.swift
-//  Created by yagom. 
+//  Created by Lingo, RED. 
 //  Copyright © yagom academy. All rights reserved.
 // 
 
@@ -87,7 +87,28 @@ func displayScoreBoard(_ strikeCount: inout Int, _ ballCount: inout Int) {
 }
 
 func main() {
-    playNumberBaseBallGame()
+    var gameStatus: Bool = true
+    
+    while gameStatus {
+        print("1. 게임시작")
+        print("2. 게임종료")
+        print("원하는 기능을 선택해주세요 : ", terminator: "")
+        
+        takePlayerIntention(&gameStatus)
+    }
+}
+
+func takePlayerIntention(_ gameStatus: inout Bool) {
+    guard let choice = readLine() else { return }
+    
+    switch choice {
+    case "1":
+        playNumberBaseBallGame()
+    case "2":
+        gameStatus = false
+    default:
+        print("입력이 잘못되었습니다")
+    }
 }
 
 main()

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -7,12 +7,13 @@
 import Foundation
 
 var targetStrikeCount: Int = 3
+var targetRange: ClosedRange<Int> = 1...9
 
-func generateRandomNumbers(from startNumber: Int = 1, to endNumber: Int = 9, quantity: Int = 3) -> [Int] {
+func generateRandomNumbers(range: ClosedRange<Int> = targetRange, quantity: Int = targetStrikeCount) -> [Int] {
     var numbers: Set<Int> = []
 
     while numbers.count < quantity {
-        numbers.insert(Int.random(in: startNumber...endNumber))
+        numbers.insert(Int.random(in: range))
     }
     return Array(numbers)
 }
@@ -55,6 +56,7 @@ func validatePlayerNumbers(_ inputNumber: String) -> Bool {
     var isNumber: Bool = false
     var isEqualWithTargetStrikeCount: Bool = false
     var isNotDuplicated: Bool = false
+    var isRanged: Bool = false
     let playerNumbers = inputNumber.components(separatedBy: " ")
     var setPlayerNumbers: Set<String> = []
     setPlayerNumbers = Set(playerNumbers)
@@ -73,7 +75,16 @@ func validatePlayerNumbers(_ inputNumber: String) -> Bool {
         isNotDuplicated = true
     }
     
-    return isNumber && isEqualWithTargetStrikeCount && isNotDuplicated
+    let intPlayerNumbers = setPlayerNumbers.compactMap { (number: String) -> Int? in
+        return Int(number)
+    }
+    
+    for number in intPlayerNumbers {
+        if targetRange.contains(number) {
+            isRanged = true
+        }
+    }
+    return isNumber && isEqualWithTargetStrikeCount && isNotDuplicated && isRanged
 }
 
 func convertInputToIntArray(_ inputNumber: String) -> [Int] {

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -46,7 +46,55 @@ func increase(in count: inout Int, condition: () -> Bool) {
 }
 
 func convertArrayToString(of values: [Int]) -> String {
-    return values.map { "\($0)" }.joined(separator: " ")
+    return values.map { (value: Int) -> String in
+        return String(value)
+    }.joined(separator: " ")
+}
+
+func validatePlayerNumbers(_ inputNumber: String) -> Bool {
+    var isNumber: Bool = false
+    var isEqualWithTargetStrikeCount: Bool = false
+    var isNotDuplicated: Bool = false
+    let playerNumbers = inputNumber.components(separatedBy: " ")
+    var setPlayerNumbers: Set<String> = []
+    setPlayerNumbers = Set(playerNumbers)
+    
+    if playerNumbers.count == targetStrikeCount {
+        isEqualWithTargetStrikeCount = true
+    }
+    
+    for numbers in playerNumbers {
+        isNumber = numbers.allSatisfy { value in
+            value.isNumber
+        }
+    }
+    
+    if playerNumbers.count == setPlayerNumbers.count {
+        isNotDuplicated = true
+    }
+    
+    return isNumber && isEqualWithTargetStrikeCount && isNotDuplicated
+}
+
+func convertInputToIntArray(_ inputNumber: String) -> [Int] {
+    let playerNumbers = inputNumber.components(separatedBy: " ")
+    return playerNumbers.compactMap { (stringNumber: String) -> Int? in
+        return Int(stringNumber)
+    }
+}
+
+func createPlayerInput() -> [Int] {
+    print("숫자 3개를 띄어쓰기로 구분하여 입력해주세요.")
+    print("중복 숫자는 허용하지 않습니다.")
+    print("입력 : ", terminator: "")
+    guard let inputNumber = readLine() else { return [] }
+    
+    if validatePlayerNumbers(inputNumber) {
+        return convertInputToIntArray(inputNumber)
+    } else {
+        print("입력이 잘못되었습니다")
+        return []
+    }
 }
 
 func playNumberBaseBallGame() {
@@ -59,10 +107,11 @@ func playNumberBaseBallGame() {
     computerNumbers = generateRandomNumbers()
     
     while matchCount > 0 {
-        print("임의의 수 : ", terminator: "")
         
-        playerNumbers = generateRandomNumbers()
-        print(convertArrayToString(of: playerNumbers))
+        playerNumbers = []
+        while playerNumbers == [] {
+            playerNumbers = createPlayerInput()
+        }
         
         strikeCount = checkStrikeCount(playerNumbers, computerNumbers)
         ballCount = checkBallCount(playerNumbers, computerNumbers)

--- a/NumberBaseball/NumberBaseball/main.swift
+++ b/NumberBaseball/NumberBaseball/main.swift
@@ -6,9 +6,6 @@
 
 import Foundation
 
-var playerNumbers: [Int] = []
-var computerNumbers: [Int] = []
-var matchCount: Int = 9
 var targetStrikeCount: Int = 3
 
 func generateRandomNumbers(from startNumber: Int = 1, to endNumber: Int = 9, quantity: Int = 3) -> [Int] {
@@ -20,7 +17,7 @@ func generateRandomNumbers(from startNumber: Int = 1, to endNumber: Int = 9, qua
     return Array(numbers)
 }
 
-func checkStrikeCount() -> Int {
+func checkStrikeCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
     var strikeCount: Int = 0
     
     for (playerNumber, computerNumber) in zip(playerNumbers, computerNumbers) {
@@ -31,7 +28,7 @@ func checkStrikeCount() -> Int {
     return strikeCount
 }
 
-func checkBallCount() -> Int {
+func checkBallCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
     var ballCount: Int = 0
     
     for (index, number) in playerNumbers.enumerated() {
@@ -53,6 +50,9 @@ func convertArrayToString(of values: [Int]) -> String {
 }
 
 func playNumberBaseBallGame() {
+    var playerNumbers: [Int] = []
+    var computerNumbers: [Int] = []
+    var matchCount: Int = 9
     var strikeCount: Int = 0
     var ballCount: Int = 0
     
@@ -64,26 +64,27 @@ func playNumberBaseBallGame() {
         playerNumbers = generateRandomNumbers()
         print(convertArrayToString(of: playerNumbers))
         
-        strikeCount = checkStrikeCount()
-        ballCount = checkBallCount()
+        strikeCount = checkStrikeCount(playerNumbers, computerNumbers)
+        ballCount = checkBallCount(playerNumbers, computerNumbers)
         
         matchCount -= 1
         
-        displayScoreBoard(&strikeCount, &ballCount)
+        displayScoreBoard(&matchCount, strikeCount, ballCount)
     }
 }
 
-func displayScoreBoard(_ strikeCount: inout Int, _ ballCount: inout Int) {
+func displayScoreBoard(_ matchCount: inout Int, _ strikeCount: Int, _ ballCount: Int) {
+    print("\(strikeCount) 스트라이크, \(ballCount) 볼")
+    
     if strikeCount == targetStrikeCount {
         matchCount = 0
         print("사용자 승리!")
-        return
     } else if matchCount == 0 {
+        print("남은 기회 : \(matchCount)")
         print("컴퓨터 승리...!")
-        return
+    } else {
+        print("남은 기회 : \(matchCount)")
     }
-    print("\(strikeCount) 스트라이크, \(ballCount) 볼")
-    print("남은 기회 : \(matchCount)")
 }
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - `Sequence Protocol`
 - `inout`
 
-## STEP 1
+## [STEP 1]
 
 ### 고민한점
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,162 @@
-## iOS 커리어 스타터 캠프
+# 숫자야구 프로젝트 저장소
+> 프로젝트 기간 2022.02.08 ~ 2022.02.11 </br>
+팀원 : [@Lingo](https://github.com/llingo) [@Red](https://github.com/cherrishRed) / 리뷰어 : [@HJEHA](https://github.com/HJEHA)
 
-### 숫자야구 프로젝트 저장소
+## 목차
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+- [프로젝트 소개](#프로젝트-소개)
+- [순서도](#순서도)
+- [키워드](#키워드)
+- [STEP 1](#step-1)
+    + [고민한점](#고민한점)
+    + [배운개념](#배운개념)
+- [STEP 2](#step-2)
+    + [고민한점](#고민한점)
+    + [배운개념](#배운개념)
+- [그라운드 룰](#그라운드-룰)
+    + [활동 시간](#활동-시간)
+    + [코딩 컨벤션](#코딩-컨벤션)
 
-## 프로젝트 그라운드 룰
 
+## 프로젝트 소개
+
+야곰과 즐기는 숫자야구 게임
+
+## 개발환경 및 라이브러리
+
+[![swift](https://img.shields.io/badge/swift-5.0-orange)]()
+[![xcode](https://img.shields.io/badge/Xcode-13.0-blue)]()
+
+## 순서도
+
+<img width="3207" alt="숫자게임 Flow Chart" src="https://user-images.githubusercontent.com/94151993/153160269-c1a967df-0782-4a59-b44a-d342010fab20.png">
+
+## 키워드
+
+- `네이밍` `함수 분리`
+- `map` `filter` `compactMap` `split` 
+- `zip` `enumerated`
+- `split vs components`
+- `Optional` `Set` `Tuple`
+- `Sequence Protocol`
+- `inout`
+
+## STEP 1
+
+### 고민한점
+
+- 네이밍
+- if, for문 중첩된 들여쓰기
+- 클로저 함수에서 후행 클로저로 줄일 때, 파라미터 리턴 키워드를 어디까지 생략하는 것이 좋은지?
+- zip함수를 사용과 인덱스 사용에 성능 차이가 있을까?
+
+
+### 배운개념
+
+**네이밍**
+
+Swift에서는 줄임말이나 관용적인 표현을 지양하는 것이 좋으며 복수형으로 변수를 네이밍하는 것이 Array, List를 붙이는 것보다 좋다.
+
+**zip 함수**
+
+`zip()` 는 두 개의 `Sequence Protocol` 을 준수한 데이터를 매개변수로 받아
+각 데이터의 값을 튜플의 쌍으로 된 `Zip2Sequence (Sequence)` 객체로 반환해주는 함수이다. 만약, 매개변수로 받은 두 데이터의 길이가 다를 시 짧은 쪽을 기준으로 `Sequence`가 생성된다. `Sequence Protocol`은 `Collection Type` 들이 가지고 있는 상위 프로토콜로 한번에 하나씩 순서를 밟아 실행할 수 있는 리스트 규약이다.
+
+```swift 
+let number1 = [1, 2, 3]
+let number2 = [4, 5, 6]
+let zipNumber = zip(number1, number2) // Zip2Sequence 객체로 반환이 되고
+
+print(Array(zipNumber)) // [(1, 4), (2, 5), (3, 6)] 으로 튜플의 형태로 나오게 됩니다.
+```
+
+**joined(separator:) 함수**
+
+```swift
+// values = [1, 2, 3] 일때,
+func convertSetToString(of values: Set<Int>) -> String {
+    let result: [String] = values.map { (number: Int) -> String in
+        return "\(number)"
+    }
+    // map 함수의 결과로 result는 ["1", "2", "3"]이 되고
+
+    return result.joined(separator: " ") // joined의 결과로 "1 2 3" 이 반환됩니다.
+}
+```
+
+위 예제 코드에서 `joined(separator:)` 는 `map()`의 결과로 반환된 [String] 배열을 separator 을 기준으로 합쳐주는 역할을 하는 메소드이다.
+
+공식 문서를 참고하면 separator는 `Sequence 프로토콜`을 채택하고 있기 때문에 `Sequence 프로토콜`을 채택하고 있는 값이라면 사용이 가능하다. 다만, separator 는 `Element`와 같은 타입이어야 한다.
+
+**In-Out 키워드에 대해**
+
+`inout`은 함수에서 직접 파라미터 값에 접근할 수 있도록 해주는 기능이다.
+(스위프트에서 파라미터는 상수로 받기 때문에 변경할 수 없지만 `inout` 키워드를 사용하면 가능하다. )
+
+
+**stride 함수**
+
+`stride(from, to, by)`는 `from`에서부터 `to` 까지 `by`의 값을 반복 연산한 결과를 `Sequence`로 반환하는 함수이다.
+
+**Set 자료형의 intersection 함수**
+
+`intersection`은 Set 타입에 사용할 수 있는 메서드로 Set 간의 교집합을 새로운 Set 타입으로 반환해주는 메서드이다.
+
+**함수 확장성에 대한 고민**
+
+함수를 구현할 때 확장성을 생각해서 구현해야한다. 파라미터 기본값을 사용하는 것도 좋은 방법이다.
+
+
+## [STEP 2]
+
+### 고민한점
+
+- 이중 들여쓰기를 사용하지 않고 반복문을 제어하는 것
+- increase 함수의 재사용성
+- 클로저 내부에서 인자의 네이밍을 어떻게 해야할 지
+- `readLine()` 관해
+    - 기존에는 `readLine()` 에서 엔터키를 눌렀을 때 `nil` 이 반환되어 옵셔널 바인딩이 필요하다고 알고 있었는데 엔터키를 눌렀을 때 빈 문자열이 반환되어 강제 언래핑을 해도 오류가 없었다.
+
+### 배운개념
+
+**디버깅 능력**
+
+문제가 발생했을 땐 의심되는 코드에 breakpoint를 걸어서 확인하는 디버깅 습관을 가지자
+
+**enumerated 함수**
+
+`enumerated()` 함수는 (n, x)의 시퀸스 쌍을 리턴해주는 메서드이다. 여기서 n은 0부터 시작하는 연속적 숫자 이며, x 는 시퀸스의 요소를 나타낸다. n이 0부터 시작하는 연속되는 숫자를 나타내기 때문에 배열에서 사용하였을 때 인덱스와 배열의 값을 튜플로 만들어서 리턴해주는 효과를 나타낼 수 있다.
+
+**allSatisfy 함수**
+
+`allSatisfy()` 함수는 요소가 조건을 만족하는지를 검사해 모든 값이 true 일 때 true를 하나라도 false 이면 false를 리턴해 주는 함수이다. `filter()` 와 비슷하지만 리턴값이 Bool 이라는 차이점이 있다.
+
+**compactMap 함수**
+
+`compactMap()` 함수는 원소를 변환된 결과가 `nil`이 아닌 것들을 배열에 담아 반환해주는 함수입니다.
+
+**출력문을 여러 줄로 출력하는 방법**
+
+```swift
+print("""
+숫자 3개를 띄어쓰기로 구분하여 입력해주세요.
+중복 숫자는 허용하지 않습니다.
+입력 :
+""", terminator: " ")
+```
+
+**ulimit 명령어**
+
+재귀 함수를 사용하는 것을 고민하다가 `Recursion limit`가 어느정도인지 궁금하였고 `ulimit -s` 명령어를 사용하여 확인한 결과 stack size는 보통 8MB까지 가능하다는 것을 알 수 있었다.
+
+## 그라운드 룰
 ### 활동 시간
-
 - **수** : 오후 2시 ~ 6시 30분
 - **목** : 세션 끝나고 식사 후 6시
 - **금** : 세션 후 잠깐 하다가 7시 30분부터 시작
 
----
-
 ### 코딩 컨벤션
-
-**Commit message**
-
+**커밋 메시지**
 ```
 feat : 새로운 기능의 추가
 fix: 버그 수정
@@ -27,9 +166,3 @@ refactor 코드 리펙토링
 test: 테스트 코트, 리펙토링 테스트 코드 추가
 chore: 빌드 업무 수정, 패키지 매니저 수정(ex .gitignore 수정 같은 경우)
 ```
-
----
-
-## Flow chart
-
-<img width="3207" alt="숫자게임 Flow Chart" src="https://user-images.githubusercontent.com/94151993/153160269-c1a967df-0782-4a59-b44a-d342010fab20.png">


### PR DESCRIPTION
@HJEHA 
안녕하세요 허황 😃
9_group의 Lingo, Red 입니다. 잘 부탁드립니다!
숫자게임 STEP 2 PR 보냅니다

## 고민한 점 & 조언을 받고 싶은 부분
- 이중 들여쓰기를 사용하지 않고 반복문을 제어하는 것
- increase 함수의 재사용성
- 클로저 내부에서 인자의 네이밍을 어떻게 해야할 지

### 어떻게 하면 `checkRanged()` 함수를 더 깔끔하게 작성할 수 있을까요?
`isRanged` 인 Bool 배열 타입의 변수를 생성하지 않고 로직을 처리하는 방법을 고민했지만 방법을 찾지 못했습니다. 🥲
```swift
func checkRanged(_ inputNumber: [Int]) -> Bool {
    var isRanged: [Bool] = []
    for number in inputNumber {
        isRanged.append(targetRange.contains(number))
    }

    return isRanged.allSatisfy { (value: Bool) -> Bool in
        return value == true
    }
}
```



### readLine() 관해
기존에는 readLine() 에서 엔터키를 눌렀을 때 nil 이 반환되어 옵셔널 바인딩이 필요하다고 알고 있었습니다. 하지만, 
엔터키를 눌렀을 때 빈 문자열이 반환되어 강제 언래핑을 해도 오류가 없었습니다.

저희는 함수를 옵셔널 바인딩 했는데도 `ctrl`+`d` 로 `EOF` 입력시 무한루프에 빠지는 오류가 나는 데 이유를 잘 모르겠습니다.

<img width="439" alt="스크린샷 2022-02-11 오후 9 26 53" src="https://user-images.githubusercontent.com/94151993/153591280-e17299c8-c7b9-479f-a8ac-fdd9aa07f5b6.png">



## 문제상황과 해결방법
- increase 함수의 재사용성을 위해 클로저를 사용하여 로직을 받도록 했었습니다. 하지만, 이중 들여쓰기와 함수의 명확성을 위배하기 때문에
`increaseStrikeCount()`, `increaseBallCount()` 함수로 기능을 분리했습니다.

```swift
func checkStrikeCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
    var strikeCount: Int = Int.zero
    
    for (playerNumber, computerNumber) in zip(playerNumbers, computerNumbers) {
        increaseStrikeCount(in: &strikeCount, playerNumber, computerNumber)
    }
    return strikeCount
}

func checkBallCount(_ playerNumbers: [Int], _ computerNumbers: [Int]) -> Int {
    var ballCount: Int = Int.zero
    
    for (index, number) in playerNumbers.enumerated() {
        increaseBallCount(in: &ballCount, computerNumbers, index, number)
    }
    return ballCount
}

func increaseStrikeCount(in count: inout Int, _ playerNumber: Int, _ computerNumber: Int) {
    if playerNumber == computerNumber {
        count += 1
    }
}

func increaseBallCount(in count: inout Int, _ computerNumbers: [Int], _ index: Int, _ number: Int) {
    if number != computerNumbers[index] && computerNumbers.contains(number) {
        count += 1
    }
}

```


- 반복문에서 이중 들여쓰기를 제거하기 위해 `inout` 키워드를 사용하여 반복 조건에서 제어할 수 있도록 변경하였습니다.
- 사용자 입력을 검증하는 `validatePlayerNumbers()` 함수에 기능이 집중되어 4개의 함수로 분리하였습니다.
